### PR TITLE
second pass - CSS variables and script injection

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,79 @@
+import React from 'react'
+
+import COLORS from './src/theming/colors'
+
+import { THEME, LIGHT, DARK } from './src/theming/constants'
+
+/*
+gatsby-ssr.js is a file which will run when Gatsby is compiling your site (at build time).
+*/
+
+const MagicScriptTag = () => {
+  const codeToRunOnClient = `
+        (function() {
+            // alert("Hi!")
+            const getInitialTheme = () => {
+                // check localStorage value, user explicitly chose light/dark
+                const persistedColorPref =
+                  typeof window !== 'undefined' && window.localStorage.getItem('${THEME}')
+
+                if (persistedColorPref) {
+                  return persistedColorPref
+                }
+
+                // check browser/OS set theme prefers-color-scheme
+                const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+                if (typeof mediaQuery.matches === 'boolean') {
+                  return mediaQuery.matches ? 'dark' : 'light'
+                }
+
+                // if they are using a browser/OS that doesn't support color themes, default to 'light'
+                return 'light'
+              }
+
+              const currentTheme = getInitialTheme()
+
+              // <html>
+              const root = document.documentElement;
+
+              // Object.entries(COLORS[currentTheme]).forEach(([cssProp, cssValue]) => {
+              //  root.style.setProperty('--color-' + cssProp, cssValue)
+              // })
+
+              root.style.setProperty(
+                '--color-text',
+                currentTheme === 'light'
+                  ? '${COLORS.light.text}'
+                  : '${COLORS.dark.text}'
+            )
+
+            root.style.setProperty(
+              '--color-background',
+              currentTheme === 'light'
+                ? '${COLORS.light.background}'
+                : '${COLORS.dark.background}'
+            )
+
+            root.style.setProperty(
+              '--color-primary',
+              currentTheme === 'light'
+                ? '${COLORS.light.primary}'
+                : '${COLORS.dark.primary}'
+            )
+
+              root.style.setProperty(
+                  '--initial-theme', currentTheme
+              )
+        })()
+    `
+
+  console.log(codeToRunOnClient)
+
+  return <script dangerouslySetInnerHTML={{ __html: codeToRunOnClient }} />
+}
+
+export const onRenderBody = ({ setPreBodyComponents }) => {
+  // inject React element above everything else, within the <body> tags
+  setPreBodyComponents(<MagicScriptTag />)
+}

--- a/src/components/pageLayout.js
+++ b/src/components/pageLayout.js
@@ -5,7 +5,6 @@ import { Helmet } from 'react-helmet'
 import { FaTwitter, FaDev, FaGithubAlt } from 'react-icons/fa'
 import { FiCodesandbox } from 'react-icons/fi'
 
-import { ThemeContext } from '../context/ThemeContext'
 import ThemeSwitch from './themeSwitch'
 import Social from './social'
 
@@ -91,68 +90,50 @@ export default function PageLayout({
   metaDescription = 'lennythedev page',
 }) {
   return (
-    <ThemeContext.Consumer>
-      {(theme) => {
-        const themeStyles = theme.isDark
-          ? {
-              backgroundColor: '#2a2b2d',
-              color: 'white',
-            }
-          : {
-              backgroundColor: 'white',
-              color: '#2a2b2d',
-            }
+    <div className="page" style={styles.body}>
+      <Helmet>
+        <meta charSet="utf-8" />
+        <title>Lenny the Dev</title>
+        <link rel="canonical" href="https://lennythedev.com" />
 
-        return (
-          <div style={{ ...styles.body, ...themeStyles }}>
-            <Helmet>
-              <meta charSet="utf-8" />
-              <title>Lenny the Dev</title>
-              <link rel="canonical" href="https://lennythedev.com" />
+        {/* OpenGraph data */}
+        <meta property="og:title" content={metaPageName} />
+        <meta property="og:url" content={metaPageUrl} />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={metaPageImage} />
+        <meta property="og:site_name" content="lennythedev" />
+        <meta property="og:locale" content="en_CA" />
+        <meta property="og:description" content={metaDescription} />
+      </Helmet>
 
-              {/* OpenGraph data */}
-              <meta property="og:title" content={metaPageName} />
-              <meta property="og:url" content={metaPageUrl} />
-              <meta property="og:type" content="website" />
-              <meta property="og:image" content={metaPageImage} />
-              <meta property="og:site_name" content="lennythedev" />
-              <meta property="og:locale" content="en_CA" />
-              <meta property="og:description" content={metaDescription} />
-            </Helmet>
-
-            {/* <h1 style={{ color: 'var(--color-primary)' }}>HAHAHA</h1> */}
-
-            <header style={styles.header}>
-              <h3 style={styles.heading}>
-                <Link to="/">lennythedev</Link>
-              </h3>
-              <Nav />
-              <div style={styles.theme}>
-                <ThemeSwitch />
-              </div>
-            </header>
-            <main style={styles.main}>{children}</main>
-            <footer style={styles.footer}>
-              <Social
-                link="https://twitter.com/lennythedev2"
-                name="Twitter"
-                icon={FaTwitter}
-              />
-              <Social
-                link="https://codesandbox.io/dashboard/recent"
-                name="Codesandbox"
-                icon={FiCodesandbox}
-              />
-              <Social link="https://dev.to/lenmorld" name="DEV" icon={FaDev} />
-              <Social
-                link="https://github.com/lenmorld"
-                name="Github"
-                icon={FaGithubAlt}
-              />
-            </footer>
-          </div>
-        )
-      }}
-    </ThemeContext.Consumer>
+      <header style={styles.header}>
+        <h3 style={styles.heading}>
+          <Link to="/">lennythedev</Link>
+        </h3>
+        <Nav />
+        <div style={styles.theme}>
+          <ThemeSwitch />
+        </div>
+      </header>
+      <main style={styles.main}>{children}</main>
+      <footer style={styles.footer}>
+        <Social
+          link="https://twitter.com/lennythedev2"
+          name="Twitter"
+          icon={FaTwitter}
+        />
+        <Social
+          link="https://codesandbox.io/dashboard/recent"
+          name="Codesandbox"
+          icon={FiCodesandbox}
+        />
+        <Social link="https://dev.to/lenmorld" name="DEV" icon={FaDev} />
+        <Social
+          link="https://github.com/lenmorld"
+          name="Github"
+          icon={FaGithubAlt}
+        />
+      </footer>
+    </div>
   )
 }

--- a/src/components/themeSwitch.js
+++ b/src/components/themeSwitch.js
@@ -1,22 +1,45 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import { FaSun, FaMoon } from 'react-icons/fa'
 
 import { ThemeContext } from '../context/ThemeContext'
+import { DARK, LIGHT } from '../theming/constants'
 
-const ThemeSwitch = () => {
-  // console.log('themeSwitch theme: ', theme)
-  return (
-    <ThemeContext.Consumer>
-      {(theme) => (
-        <button
-          className="theme-switch"
-          type="button"
-          onClick={theme.toggleTheme}
-        >
-          {theme.isDark ? <span>☀️</span> : <span>🌙</span>}
-        </button>
-      )}
-    </ThemeContext.Consumer>
-  )
+const styles = {
+  cursor: 'pointer',
+  background: 'none',
+  border: 'none',
+  color: '#ffdf00',
+  fontSize: '1rem',
+  marginTop: '5px',
 }
 
-export default ThemeSwitch
+export default function ThemeSwitch() {
+  // useContext simplifies context usage, no need to wrap element with render prop
+  const themeState = useContext(ThemeContext)
+
+  // don't render switch on first compile-time pass
+  if (!themeState) {
+    return null
+  }
+
+  const { theme, setTheme } = themeState
+
+  const toggleTheme = () => {
+    if (theme === LIGHT) {
+      setTheme(DARK)
+    } else {
+      setTheme(LIGHT)
+    }
+  }
+
+  return (
+    <button
+      style={styles}
+      className="theme-switch"
+      type="button"
+      onClick={toggleTheme}
+    >
+      {theme === DARK ? <FaMoon /> : <FaSun />}
+    </button>
+  )
+}

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,30 +1,48 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { getInitialTheme, persistTheme } from '../theming/helper'
+
+import COLORS from '../theming/colors'
 
 export const ThemeContext = React.createContext()
 
 export const ThemeProvider = ({ children }) => {
-  const [theme, setTheme] = React.useState(getInitialTheme)
+  const [theme, rawSetTheme] = useState(undefined)
 
-  const isDark = theme === 'dark'
+  useEffect(() => {
+    const root = window.document.documentElement
 
-  const setThemeAndPersist = (value) => {
-    setTheme(value)
-    persistTheme(value)
-  }
+    const initialTheme = root.style.getPropertyValue('--initial-theme')
 
-  const toggleTheme = () => {
-    console.log(theme)
-    if (theme === 'dark') {
-      setThemeAndPersist('light')
-    } else if (theme === 'light') {
-      setThemeAndPersist('dark')
-    }
+    rawSetTheme(initialTheme)
+  }, [])
+
+  const setTheme = (newValue) => {
+    const root = window.document.documentElement
+
+    // update state
+    rawSetTheme(newValue)
+    // persist to localStorage
+    persistTheme(newValue)
+    // update styles
+    root.style.setProperty(
+      '--color-text',
+      newValue === 'light' ? COLORS.light.text : COLORS.dark.text,
+    )
+
+    root.style.setProperty(
+      '--color-background',
+      newValue === 'light' ? COLORS.light.background : COLORS.dark.background,
+    )
+
+    root.style.setProperty(
+      '--color-primary',
+      newValue === 'light' ? COLORS.light.primary : COLORS.dark.primary,
+    )
   }
 
   return (
-    <ThemeContext.Provider value={{ isDark, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,6 +18,15 @@ body {
     margin: 0 auto;
 }
 
+/** theming **/
+body {
+    /* background-color: #2a2b2d; */
+    background-color: var(--color-background);
+    /* color: #393424; */
+    color: var(--color-text);
+    transition: background 0.6s ease;
+}
+
 /* ---- from typography.js ---- */
 h1,
 h2,
@@ -98,27 +107,3 @@ img {
 
 
 /** end of typography.js **/
-
-
-/**** theming ***/
-
- .dark {
-    background-color: #2a2b2d;
-    color: white;
-    transition: all 0.6s ease;
-}
-
-.light {
-    background-color: white;
-    color: #393424;
-    transition: all 0.6s ease;
-} 
-
-.theme-switch {
-    cursor: pointer;
-    border: none;
-    background: none;
-}
-
-
-

--- a/src/theming/colors.js
+++ b/src/theming/colors.js
@@ -1,0 +1,10 @@
+export default {
+  light: {
+    text: 'black',
+    background: 'white',
+  },
+  dark: {
+    text: 'white',
+    background: 'black',
+  },
+}

--- a/src/theming/constants.js
+++ b/src/theming/constants.js
@@ -1,0 +1,3 @@
+export const THEME = 'theme'
+export const DARK = 'dark'
+export const LIGHT = 'light'

--- a/src/theming/helper.js
+++ b/src/theming/helper.js
@@ -1,27 +1,8 @@
-import { THEME, DARK, LIGHT } from './constants'
+import { THEME } from './constants'
 
-export const getInitialTheme = () => {
-  // check localStorage value, user explicitly chose light/dark
-  const persistedColorPref =
-    typeof window !== 'undefined' && window.localStorage.getItem(THEME)
-
-  if (persistedColorPref) {
-    return persistedColorPref
-  }
-
-  // check browser/OS set theme prefers-color-scheme
-  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-
-  if (typeof mediaQuery.matches === 'boolean') {
-    return mediaQuery.matches ? DARK : LIGHT
-  }
-
-  // if they are using a browser/OS that doesn't support color themes, default to 'light'
-  return LIGHT
-}
+// --- moved to gatsby-ssr.js ---
+// export const getInitialTheme = () => {...}
 
 export const persistTheme = (theme) => {
   typeof window !== 'undefined' && window.localStorage.setItem(THEME, theme)
 }
-
-// export const a = 1


### PR DESCRIPTION
- set CSS variables on <html> root
- gatsby-ssr: on build time, inject script that gets theme and sets CSS vars on root
  - move getInitialTheme from theming/helper.js to here and stringify
- global.css: use CSS var in body, so they apply to entire app when root html CSS var value changes
- pageLayout: remove context usage since
  - entire app is already wrapped in context in wrapRootElement (gatsby-browser)
  - styles already set in body

results:
![image](https://user-images.githubusercontent.com/14609656/120931634-77270b00-c6c0-11eb-888e-7ae8ec72dc50.png)
