### PR TITLE
use function expression and replace when Stringify

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -18,8 +18,13 @@ function setColorsByTheme() {
   const light = '🌞' // LIGHT
   const dark = '🌝' // DARK
 
-  // same for function, but we replace in place, since it's called, not assigned
-  // see functionPlaceholderSetCssVarColors
+  // same for function, we must assign a token and replace with Stringified imported function after
+  // NOTE that we cannot just replace in place, since when building there are
+  // optimizations that causes the imported function to be replaced with an anonymous function
+  // thus not callable by main function
+  // https://www.notion.so/lennythedev/L102-Light-dark-theme-0d94ba42c7d14a028e27024ddbed7c3e#0ff17517e94f4f1a8a9870aa7fd216e7
+
+  const functionPlaceholderSetCssVarColors = '✨'
 
   // alert("Hi!")
 
@@ -58,9 +63,7 @@ const MagicScriptTag = () => {
   const setColorsByThemeString = String(setColorsByTheme)
 
   const stringifiedCode = `
-        ${helpersString}
         ${setColorsByThemeString}
-        
         // call main function
         setColorsByTheme()
     `
@@ -72,7 +75,7 @@ const MagicScriptTag = () => {
     .replace("'🔲'", `'${THEME}'`)
     .replace("'🌞'", `'${LIGHT}'`)
     .replace("'🌝'", `'${DARK}'`)
-    .replace(/functionPlaceholderSetCssVarColors/g, 'setCssVarColors')
+    .replace("'✨'", helpersString) // replace function
 
   // wrap in IIFE
   const codeToRunOnClient = `(


### PR DESCRIPTION
Problem:
when building into deployed version, optimizations of scripts causes helper function to be replaced with an anonymous function, thus not callable by main function

![image](https://user-images.githubusercontent.com/14609656/121446884-8b8a3280-c962-11eb-98da-112870688b06.png)
![image](https://user-images.githubusercontent.com/14609656/121446928-9cd33f00-c962-11eb-8a3f-be97c8e3035d.png)


Fix:
use function expression with a token
and replace later with Stringified imported function

![image](https://user-images.githubusercontent.com/14609656/121446998-c0968500-c962-11eb-9e97-24ebc66c8647.png)
