### PR TITLE
fix nav items alignment and wrap

### DIFF
--- a/src/components/pageLayout.js
+++ b/src/components/pageLayout.js
@@ -11,15 +11,22 @@ import Social from './social'
 const styles = {
   body: {},
   header: {
-    marginTop: `1.5rem`,
+    marginTop: `2rem`,
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     flexWrap: 'wrap',
   },
+  left: {
+    marginBottom: '1rem',
+  },
   heading: {
-    margin: '1rem 2rem 0 0',
+    margin: 0,
+  },
+  right: {
+    display: 'flex',
+    marginBottom: '1rem',
   },
   nav: {
     listStyle: 'none',
@@ -27,10 +34,11 @@ const styles = {
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
-    margin: '1rem 0 0 0',
+    margin: 0,
+    padding: 0,
   },
-  theme: {
-    margin: '1rem 0 0 0',
+  themeSwitch: {
+    marginLeft: '1rem',
   },
   main: {
     // marginTop: '1.5rem',
@@ -107,12 +115,16 @@ export default function PageLayout({
       </Helmet>
 
       <header style={styles.header}>
-        <h3 style={styles.heading}>
-          <Link to="/">lennythedev</Link>
-        </h3>
-        <Nav />
-        <div style={styles.theme}>
-          <ThemeSwitch />
+        <div style={styles.left}>
+          <h3 style={styles.heading}>
+            <Link to="/">lennythedev</Link>
+          </h3>
+        </div>
+        <div style={styles.right}>
+          <Nav />
+          <div style={styles.themeSwitch}>
+            <ThemeSwitch />
+          </div>
         </div>
       </header>
       <main style={styles.main}>{children}</main>


### PR DESCRIPTION
header
- enclose h3 and Nav+themSwich into left and right containers
- flex space-between left and right
- margin from top of page
- left and right: margin bottom to alow for space when smaller viewport
- some other alignment fixes


before:
![image](https://user-images.githubusercontent.com/14609656/121512731-0893c700-c9b8-11eb-81cc-6999e9b13395.png)
![image](https://user-images.githubusercontent.com/14609656/121512764-0fbad500-c9b8-11eb-84be-c1b8d77730e6.png)


after:
![image](https://user-images.githubusercontent.com/14609656/121512813-1e08f100-c9b8-11eb-8a3b-4dc52f35ffd8.png)
![image](https://user-images.githubusercontent.com/14609656/121512833-252fff00-c9b8-11eb-878d-4f35318ee3ae.png)
