### PR TITLE
L106 make header sticky fixes

### DIFF
--- a/src/components/pageLayout.js
+++ b/src/components/pageLayout.js
@@ -16,12 +16,7 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'space-between',
     flexWrap: 'wrap',
-    // marginTop: `2rem`,
-    paddingTop: `2rem`,
-    position: 'sticky',
-    top: 0,
-    backgroundColor: 'var(--color-background)',
-    zIndex: '1', // prevent blog elements from going on top
+    // other styles in global.css header {}
   },
   left: {
     marginBottom: '1rem',
@@ -47,7 +42,7 @@ const styles = {
   },
   main: {
     // marginTop: '1.5rem',
-    minHeight: '75vh',
+    // minHeight: '75vh',
   },
   footer: {
     borderTop: '1px solid gray',
@@ -119,16 +114,20 @@ export default function PageLayout({
         <meta property="og:description" content={metaDescription} />
       </Helmet>
 
-      <header style={styles.header}>
-        <div style={styles.left}>
-          <h3 style={styles.heading}>
-            <Link to="/">lennythedev</Link>
-          </h3>
-        </div>
-        <div style={styles.right}>
-          <Nav />
-          <div style={styles.themeSwitch}>
-            <ThemeSwitch />
+      <header>
+        <div className="max-width-container">
+          <div style={styles.header}>
+            <div style={styles.left}>
+              <h3 style={styles.heading}>
+                <Link to="/">lennythedev</Link>
+              </h3>
+            </div>
+            <div style={styles.right}>
+              <Nav />
+              <div style={styles.themeSwitch}>
+                <ThemeSwitch />
+              </div>
+            </div>
           </div>
         </div>
       </header>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -13,7 +13,9 @@ const styles = {
     display: 'grid',
     columnGap: '4rem',
     rowGap: '1rem',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))',
+    // NOTE: make min lot less than phone viewport (300-400) so
+    // it won't overflow on phones
+    gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
     // grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
 
     // display: "flex",
@@ -101,6 +103,7 @@ const Project = ({
         display: 'flex',
         alignItems: 'center',
         marginBottom: '0.75rem',
+        flexWrap: 'wrap',
       }}
     >
       {tags.map((tag) => (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,8 +22,8 @@ body {
 
 body {
     font-family: 'Quattrocento Sans', sans-serif;
-    max-width: 80%;
-    margin: 0 auto;
+    /* max-width: 80%; */
+    /* margin: 0 auto; */
 }
 
 /** theming **/
@@ -33,6 +33,28 @@ body {
     /* color: #393424; */
     color: var(--color-text);
     transition: background 0.6s ease;
+}
+
+header {
+    background-color: var(--color-background);
+    transition: background 0.6s ease;
+
+    position: sticky;
+    top: 0;
+    /* backgroundColor: 'var(--color-background)', */
+    z-index: 1; /* prevent blog elements from going on top */
+}
+
+header .max-width-container {
+    max-width: 80%;
+    margin: 0 auto;
+    padding: 2rem 2rem 0 2rem;
+}
+
+main {
+    min-height: 75vh;
+    max-width: 80%;
+    margin: 0 auto;
 }
 
 /* ---- from typography.js ---- */


### PR DESCRIPTION
wrap header body in a max-width-container
- move header styles to global.css
- wrap entire header(title, nav, theme switch) in max-width-container

improve responsiveness
- enlarge min width of grid - less than smaller phones (300, 400)
- wrap the tags flex container

css header styles